### PR TITLE
Remove urbansim dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - pandas >=0.22
     - patsy >=0.4
     - statsmodels >=0.8
-    - 'urbansim[channel=udst]'
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,14 +20,14 @@ requirements:
     - python
     - pip
   run:
+    - python
     - choicemodels >=0.2
     - numpy >=1.14
     - orca >=1.4
     - pandas >=0.22
     - patsy >=0.4
-    - python
     - statsmodels >=0.8
-    - udst::urbansim >=3.1
+    - 'urbansim[channel=udst]'
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - patsy >=0.4
     - python
     - statsmodels >=0.8
-    - urbansim >=3.1
+    - udst::urbansim >=3.1
 
 test:
   imports:


### PR DESCRIPTION
This PR removes the `urbansim` dependency from the recipe. It's not on `conda-forge` so was [preventing the feedstock from building](https://circleci.com/gh/conda-forge/urbansim_templates-feedstock/1). Based on the CI tests, this seems to be working. 

For now, i'll update the documentation to instruct users to install `urbansim` separately. And will work on getting `urbansim` onto `conda-forge` when i have a chance.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged) -- _i assume this is not necessary since there hasn't been a successful build yet_
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->